### PR TITLE
Django 17 and 18

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,20 +13,28 @@ env:
     - TOXENV=py27-django15
     - TOXENV=py27-django15-cdecimal
     - TOXENV=py27-django16
+    - TOXENV=py27-django17
+    - TOXENV=py27-django18
     - TOXENV=py32-django15
     - TOXENV=py32-django16
     - TOXENV=py33-django15
     - TOXENV=py33-django15-cdecimal
     - TOXENV=py33-django16
+    - TOXENV=py33-django17
+    - TOXENV=py33-django18
     - TOXENV=py34-django15
     - TOXENV=py34-django15-cdecimal
     - TOXENV=py34-django16
+    - TOXENV=py34-django17
+    - TOXENV=py34-django18
     - TOXENV=pypy-django11
     - TOXENV=pypy-django12
     - TOXENV=pypy-django13
     - TOXENV=pypy-django14
     - TOXENV=pypy-django15
     - TOXENV=pypy-django16
+    - TOXENV=pypy-django17
+    - TOXENV=pypy-django18
     - TOXENV=cov
 matrix:
     allow_failures:

--- a/README.rst
+++ b/README.rst
@@ -88,7 +88,7 @@ Version Support
 
 This module supports Python 2.6–2.7 and 3.2–3.4 as well as PyPy.
 
-Supported Django versions are 1.1 to 1.6.
+Supported Django versions are 1.1 to 1.8.
 
 See https://travis-ci.org/dbrgn/django-mathfilters for the full build matrix.
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,12 +2,12 @@
 [tox]
 envlist =
     py26-django11, py26-django12, py26-django13, py26-django14, py26-django15, py26-django16,
-    py27-django11, py27-django12, py27-django13, py27-django14, py27-django15, py27-django15-cdecimal, py27-django16,
+    py27-django11, py27-django12, py27-django13, py27-django14, py27-django15, py27-django15-cdecimal, py27-django16, py27-django17, py27-django18,
     py32-django15, py32-django16,
-    py33-django15, py33-django15-cdecimal, py33-django16,
-    py34-django15, py34-django15-cdecimal, py34-django16,
-    pypy-django11, pypy-django12, pypy-django13, pypy-django14, pypy-django15, pypy-django16,
-    pypy3-django15, pypy3-django16
+    py33-django15, py33-django15-cdecimal, py33-django16, py33-django17, py33-django18,
+    py34-django15, py34-django15-cdecimal, py34-django16, py34-django17, py34-django18,
+    pypy-django11, pypy-django12, pypy-django13, pypy-django14, pypy-django15, pypy-django16, pypy-django17, pypy-django18,
+    pypy3-django15, pypy3-django16, pypy3-django17, pypy3-django18
 
 [testenv]
 commands =
@@ -88,6 +88,16 @@ basepython=python2.7
 deps=
     django<1.7
 
+[testenv:py27-django17]
+basepython=python2.7
+deps=
+    django<1.8
+
+[testenv:py27-django18]
+basepython=python2.7
+deps=
+    django<1.9
+
 # Python 3.2
 
 [testenv:py32-django15]
@@ -118,6 +128,16 @@ basepython=python3.3
 deps=
     django<1.7
 
+[testenv:py33-django17]
+basepython=python3.3
+deps=
+    django<1.8
+
+[testenv:py33-django18]
+basepython=python3.3
+deps=
+    django<1.8
+
 # Python 3.4
 
 [testenv:py34-django15]
@@ -135,6 +155,16 @@ deps=
 basepython=python3.4
 deps=
     django<1.7
+
+[testenv:py34-django17]
+basepython=python3.4
+deps=
+    django<1.8
+
+[testenv:py34-django18]
+basepython=python3.4
+deps=
+    django<1.9
 
 # Pypy
 
@@ -168,6 +198,16 @@ basepython=pypy
 deps=
     django<1.7
 
+[testenv:pypy-django17]
+basepython=pypy
+deps=
+    django<1.8
+
+[testenv:pypy-django18]
+basepython=pypy
+deps=
+    django<1.9
+
 [testenv:pypy3-django15]
 basepython=pypy3
 deps=
@@ -177,6 +217,16 @@ deps=
 basepython=pypy3
 deps=
     django<1.7
+
+[testenv:pypy3-django17]
+basepython=pypy3
+deps=
+    django<1.8
+
+[testenv:pypy3-django18]
+basepython=pypy3
+deps=
+    django<1.8
 
 ############ Special Cases ############
 


### PR DESCRIPTION
This PR adds the testing environment for django-mathfilters in Django1.7 and Django1.8 in python2.7, python3.3, python3.4, pypy and pypy3.